### PR TITLE
fix: merge i18next/react-i18next into vendor-react chunk to resolve c…

### DIFF
--- a/vite.config.web.mts
+++ b/vite.config.web.mts
@@ -18,7 +18,9 @@ export default defineConfig({
           if (
             id.includes("/react/") ||
             id.includes("/react-dom/") ||
-            id.includes("/scheduler/")
+            id.includes("/scheduler/") ||
+            id.includes("i18next") ||
+            id.includes("react-i18next")
           ) {
             return "vendor-react";
           }
@@ -27,9 +29,6 @@ export default defineConfig({
           }
           if (id.includes("@tanstack")) {
             return "vendor-query";
-          }
-          if (id.includes("i18next") || id.includes("react-i18next")) {
-            return "vendor-i18n";
           }
           if (id.includes("lucide-react")) {
             return "vendor-icons";


### PR DESCRIPTION
…ircular dependency

The manualChunks config separated react and i18next into different chunks, but react-i18next imports createContext from react, creating a circular dependency. This caused 'Cannot read properties of undefined (reading createContext)' at runtime in web mode, resulting in a blank page.

Fix: include i18next and react-i18next in the same vendor-react chunk.