### PR TITLE
fix(web): guard stream-check API with isWeb() to prevent invoke crash

### DIFF
--- a/src/lib/api/model-test.ts
+++ b/src/lib/api/model-test.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { isWeb } from "./adapter";
 import type { AppId } from "./types";
 
 // ===== 流式健康检查类型 =====
@@ -54,6 +55,24 @@ export interface StreamCheckLogQuery {
   offset?: number;
 }
 
+// ===== Web 模式适配 =====
+// 流式健康检查依赖 host 端 Tauri command（stream_check_*），仅在桌面 native 运行时可用。
+// web/headless 模式下 capabilities.endpointTest === false，Tauri invoke 不可用，
+// 若直接调用会抛 "Cannot read properties of undefined (reading 'invoke')"。
+// 因此 web 模式下返回安全的空值/noop，保持 UI 可用（历史为空、测试按钮不触发真实请求）。
+const STREAM_CHECK_DISABLED_WEB_MESSAGE =
+  "Stream check is not available in web/headless mode";
+
+const DEFAULT_WEB_STREAM_CHECK_CONFIG: StreamCheckConfig = {
+  timeoutSecs: 30,
+  maxRetries: 1,
+  degradedThresholdMs: 3000,
+  claudeModel: "",
+  codexModel: "",
+  geminiModel: "",
+  testPrompt: "",
+};
+
 // ===== 流式健康检查 API =====
 
 /**
@@ -63,6 +82,16 @@ export async function streamCheckProvider(
   appType: AppId,
   providerId: string,
 ): Promise<StreamCheckResult> {
+  if (isWeb()) {
+    return {
+      status: "failed",
+      success: false,
+      message: STREAM_CHECK_DISABLED_WEB_MESSAGE,
+      modelUsed: "",
+      testedAt: Date.now(),
+      retryCount: 0,
+    };
+  }
   return invoke("stream_check_provider", { appType, providerId });
 }
 
@@ -73,6 +102,9 @@ export async function streamCheckAllProviders(
   appType: AppId,
   proxyTargetsOnly: boolean = false,
 ): Promise<Array<[string, StreamCheckResult]>> {
+  if (isWeb()) {
+    return [];
+  }
   return invoke("stream_check_all_providers", { appType, proxyTargetsOnly });
 }
 
@@ -80,6 +112,9 @@ export async function streamCheckAllProviders(
  * 获取流式检查配置
  */
 export async function getStreamCheckConfig(): Promise<StreamCheckConfig> {
+  if (isWeb()) {
+    return DEFAULT_WEB_STREAM_CHECK_CONFIG;
+  }
   return invoke("get_stream_check_config");
 }
 
@@ -89,17 +124,26 @@ export async function getStreamCheckConfig(): Promise<StreamCheckConfig> {
 export async function saveStreamCheckConfig(
   config: StreamCheckConfig,
 ): Promise<void> {
+  if (isWeb()) {
+    return;
+  }
   return invoke("save_stream_check_config", { config });
 }
 
 export async function getStreamCheckLogs(
   query: StreamCheckLogQuery = {},
 ): Promise<StreamCheckLog[]> {
+  if (isWeb()) {
+    return [];
+  }
   return invoke("get_stream_check_logs", { query });
 }
 
 export async function getLatestStreamCheckLogs(
   appType?: AppId,
 ): Promise<StreamCheckLog[]> {
+  if (isWeb()) {
+    return [];
+  }
   return invoke("get_latest_stream_check_logs", { appType });
 }


### PR DESCRIPTION
## Problem

In **web/headless mode**, opening the Providers page (the default landing page right after login) throws an uncaught error and breaks the UI:

```
Cannot read properties of undefined (reading 'invoke')
```

## Reproduce

1. Deploy the prebuilt `cc-switch-server-linux-x86_64` (v0.21.0) and open the web console in a browser.
2. Log in.
3. The Providers page auto-loads → the error fires immediately, no user action needed.

## Root cause

`src/lib/api/model-test.ts` is the only web-API module that still calls Tauri `invoke()` directly without an `isWeb()` guard. In a browser there is no `window.__TAURI__`, so `invoke` is `undefined`:

```ts
export async function getLatestStreamCheckLogs(appType?: AppId): Promise<StreamCheckLog[]> {
  return invoke("get_latest_stream_check_logs", { appType }); // ← throws in web mode
}
```

The crash is triggered **automatically on page load**, not by a user action:

- `src/components/providers/ProviderList.tsx` subscribes `useLatestStreamCheckHistory(appId)`
- its `queryFn` calls `getLatestStreamCheckLogs(appId)` → `invoke(...)` → crash
- the query's `enabled` flag is `true` for `claude` / `codex` / `gemini` (the common default apps)

This contradicts the capability contract — `/api/capabilities` reports `runtime: "web"` and `features.endpointTest: false` — yet the stream-check module still reaches for the Tauri bridge. Every other web-aware module already short-circuits with `isWeb()`:

- `src/lib/api/providers.ts` → `onSwitched` returns a noop unsubscriber
- `src/hooks/useDirectorySettings.ts` → returns `null` / default dir
- `src/lib/updater.ts` → returns `"up-to-date"`

…so `model-test.ts` is the outlier.

## Fix

Add `isWeb()` guards to all six stream-check functions, returning safe defaults in web mode:

| function | web-mode return |
|---|---|
| `getStreamCheckLogs` | `[]` |
| `getLatestStreamCheckLogs` | `[]` |
| `streamCheckAllProviders` | `[]` |
| `streamCheckProvider` | a `failed` `StreamCheckResult` |
| `getStreamCheckConfig` | a default config |
| `saveStreamCheckConfig` | noop |

Desktop/native behavior is unchanged.

## Validation

- `pnpm typecheck` → ✅ passes (`tsc --noEmit`)
- `pnpm format:check` → `model-test.ts` is clean (the 2 warnings reported are pre-existing on `main`, unrelated to this change)
- Built and deployed the server (`pnpm build:web` + `cargo build --release --no-default-features --features web-server --example server`) to a headless host; backend API verified healthy after restart.

## Scope

Single-file change, +44 / -0. No behavior change for desktop builds.
