### PR TITLE
fix: preserve Codex MCP servers when syncing current providers to live

### DIFF
--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -398,6 +398,31 @@ impl ConfigService {
         };
 
         crate::codex_config::write_codex_live_atomic(auth, cfg_text)?;
+
+        // v3.7.0+ 运行时配置从 SQLite 加载，MCP 服务器只存在于统一结构
+        // `mcp.servers`，旧的分应用结构恒为空。与 McpService::sync_all_enabled
+        // 一致，先把统一结构中启用了 Codex 的条目投影到旧结构，否则
+        // sync_enabled_to_codex 会误判为“无启用项”而清空 live config.toml 的
+        // [mcp_servers] 表（旧结构中已有的条目保持不变）。
+        if let Some(servers) = &config.mcp.servers {
+            let projected: Vec<(String, Value)> = servers
+                .values()
+                .filter(|server| server.apps.codex)
+                .map(|server| {
+                    (
+                        server.id.clone(),
+                        serde_json::json!({
+                            "id": server.id,
+                            "enabled": true,
+                            "server": server.server,
+                        }),
+                    )
+                })
+                .collect();
+            for (id, entry) in projected {
+                config.mcp.codex.servers.entry(id).or_insert(entry);
+            }
+        }
         crate::mcp::sync_enabled_to_codex(config)?;
 
         let cfg_text_after = crate::codex_config::read_and_validate_codex_config_text()?;

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 
 use cc_switch_lib::{
     get_claude_settings_path, get_codex_config_path, read_json_file, write_codex_live_atomic,
-    AppError, AppState, AppType, MultiAppConfig, Provider, ProviderMeta, ProviderService,
+    AppError, AppState, AppType, ConfigService, MultiAppConfig, Provider, ProviderMeta,
+    ProviderService,
 };
 
 #[path = "support.rs"]
@@ -1115,6 +1116,113 @@ fn provider_service_update_current_codex_preserves_mcp_in_live_and_snapshot() {
     let manager = guard
         .get_manager(&AppType::Codex)
         .expect("codex manager after update");
+    let current = manager
+        .providers
+        .get("current")
+        .expect("current provider should still exist");
+    let snapshot_config = current
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        snapshot_config.contains("mcp_servers.relay-pulse"),
+        "stored provider snapshot should match live config with MCP servers"
+    );
+}
+
+#[test]
+fn sync_current_providers_preserves_codex_mcp_in_live_and_snapshot() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "current".to_string();
+        manager.providers.insert(
+            "current".to_string(),
+            Provider::with_id(
+                "current".to_string(),
+                "Current Codex".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "stale-key"},
+                    "config": "model = \"gpt-4.1\"\n"
+                }),
+                None,
+            ),
+        );
+    }
+
+    config.mcp.codex.servers.insert(
+        "relay-pulse".into(),
+        json!({
+            "id": "relay-pulse",
+            "enabled": true,
+            "server": {
+                "type": "stdio",
+                "command": "relay-pulse"
+            }
+        }),
+    );
+
+    // 与上面的官方场景一致，但经 AppState/SQLite 往返：加载回来的配置只有
+    // 统一结构 mcp.servers，旧的分应用结构恒为空（v3.7.0+ 的生产形态）。
+    let state = AppState::new_for_tests(config).expect("test app state");
+
+    ProviderService::update(
+        &state,
+        AppType::Codex,
+        Provider::with_id(
+            "current".to_string(),
+            "Current Codex".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "fresh-key"},
+                "config": "model = \"gpt-5\"\n"
+            }),
+            None,
+        ),
+    )
+    .expect("updating current codex provider should succeed");
+
+    let config_path = unwrap_path(get_codex_config_path());
+    let before = std::fs::read_to_string(&config_path).expect("read config.toml");
+    assert!(
+        before.contains("mcp_servers.relay-pulse"),
+        "sanity: live config.toml should contain MCP server before sync-current"
+    );
+
+    // POST /api/providers/sync-current（web 前端每次切换供应商后必调）、
+    // POST /api/config/import、备份恢复等入口共用的确切调用。
+    state
+        .update_config(ConfigService::sync_current_providers_to_live)
+        .expect("sync current providers to live");
+
+    let auth_path = unwrap_path(cc_switch_lib::get_codex_auth_path());
+    let auth_value: serde_json::Value = read_json_file(&auth_path).expect("read auth.json");
+    assert_eq!(
+        auth_value.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+        Some("fresh-key"),
+        "live auth.json should keep updated provider auth"
+    );
+
+    let config_text = std::fs::read_to_string(&config_path).expect("read config.toml");
+    assert!(
+        config_text.contains("mcp_servers.relay-pulse"),
+        "config.toml should preserve enabled MCP servers after syncing current providers"
+    );
+    assert!(
+        config_text.contains("command = \"relay-pulse\""),
+        "config.toml should contain relay-pulse command after sync"
+    );
+
+    let guard = state.load_config().expect("read config after sync");
+    let manager = guard
+        .get_manager(&AppType::Codex)
+        .expect("codex manager after sync");
     let current = manager
         .providers
         .get("current")


### PR DESCRIPTION
Fixes #38

### 修复什么

Web 模式每次切换供应商（前端在 `switch_provider` 成功后固定跟调 `POST /api/providers/sync-current`，见 `src/lib/api/providers.ts:74-84`）、导入配置、恢复备份、桌面手动同步时，`~/.codex/config.toml` 的整个 `[mcp_servers]` 表会被清空，Codex CLI 随即丢失全部 MCP 服务器；被清空后的文本还会回写进存储的供应商快照。

### 根因与修复方式

`ConfigService::sync_codex_live` 直接调用 `mcp::sync_enabled_to_codex(config)`（`services/config.rs:401`），而后者只从旧的分应用结构 `config.mcp.codex.servers` 收集启用项（`mcp/sync.rs:79`）。v3.7.0 起运行时配置一律从 SQLite 加载，`Database::load_mcp_root` 只填充统一结构 `mcp.servers`、旧结构恒为空，于是恒命中"无启用项 → 移除 `mcp_servers` 表"分支（`mcp/sync.rs:104-106`）。

修复与 `McpService::sync_all_enabled`（`services/mcp.rs:247-317`）已有的做法保持一致：调用 `sync_enabled_to_codex` 之前，把统一结构中 `apps.codex == true` 的条目以 `{"id", "enabled": true, "server"}` 形态投影进 `config.mcp.codex.servers`。投影用 `entry(id).or_insert(...)` 只补缺、不覆盖已有条目，因此仍直接使用旧结构形态的调用方（如既有测试 `sync_codex_provider_writes_auth_and_config`）行为完全不变。改动仅影响 Codex 同步来源；Claude / Gemini 的 live 同步路径不经过此函数，不受影响。

### 回归测试

新增 `sync_current_providers_preserves_codex_mcp_in_live_and_snapshot`（`tests/provider_service.rs`，紧跟在官方测试 `provider_service_update_current_codex_preserves_mcp_in_live_and_snapshot` 之后）：场景与官方测试一致，但配置经 `AppState`/SQLite 往返（v3.7.0+ 的生产形态，MCP 只在统一结构中），随后执行 `state.update_config(ConfigService::sync_current_providers_to_live)`——即 sync-current / 导入 / 恢复备份各入口共用的确切调用——并断言官方测试同款契约（live 与快照均保留 MCP、auth 正常写回）。

修复前该测试失败（红）：

```
$ cargo test --test provider_service sync_current_providers_preserves_codex_mcp --features test-hooks
test sync_current_providers_preserves_codex_mcp_in_live_and_snapshot ... FAILED
panicked: config.toml should preserve enabled MCP servers after syncing current providers
```

修复后通过（绿），并跑了全量测试确认无回归（macOS，Rust stable / Cargo 1.95）：

```
$ cargo test --tests --features test-hooks            # CI 集成测试同款
  全部通过（lib 单测 390 passed；全部集成测试目标 0 failed，
  含 import_export_sync 27 passed、provider_service 19 passed）

$ cargo test --tests --no-default-features --features web-server,test-hooks
  全部通过（lib 单测 393 passed；全部集成测试目标 0 failed）

$ cargo test --test provider_service --test import_export_sync --test mcp_commands \
    --no-default-features --features web-server        # 纯 web-server feature
  provider_service 19 passed / import_export_sync 27 passed / mcp_commands 0 failed

$ cargo test --lib                                     # CI Test 同款
  390 passed; 0 failed

$ cargo clippy --lib -- -D warnings                    # 通过
$ cargo fmt -- --check                                 # 通过
$ cargo check --features web-server --example server   # CI web-server 检查同款，通过
```

说明：纯 `--no-default-features --features web-server` 下 `--tests` 整体编译不过，是既有问题——`tests/web_auth_center.rs` 用到的 `get_raw_managed_auth_tokens_for_tests` 门控在 `#[cfg(any(test, feature = "test-hooks"))]`（`database/dao/auth.rs:348`），与本改动无关（CI 对 web-server 也只跑 `cargo check --example server`）；因此纯 web-server 下改跑了相关测试目标，并补跑了 `web-server,test-hooks` 组合的全量。

---

### English summary

`ConfigService::sync_codex_live` calls `mcp::sync_enabled_to_codex(config)`, which only collects enabled servers from the legacy per-app map `config.mcp.codex.servers`. Since v3.7.0 runtime configs are loaded from SQLite where that map is always empty, so every `sync_current_providers_to_live` entry point (web `POST /api/providers/sync-current` fired after **every** provider switch, config import, backup restore, desktop manual sync) hit the "no enabled servers → remove `mcp_servers`" branch and wiped the whole `[mcp_servers]` table from `~/.codex/config.toml`, then persisted the wiped text into the stored provider snapshot. The fix mirrors the unified→legacy projection that `McpService::sync_all_enabled` already performs before calling the same function, using `entry(id).or_insert(...)` so configs still carrying legacy-shaped entries behave exactly as before. Regression test added right next to `provider_service_update_current_codex_preserves_mcp_in_live_and_snapshot`, mirroring its scenario through an `AppState`/SQLite round-trip; it fails before the fix and passes after. Full suites green under both `test-hooks` and `web-server,test-hooks` feature sets; clippy/fmt clean.

---

本 PR 在 AI 辅助下完成，作者已本地复现问题并逐行审阅修复与测试。
